### PR TITLE
refs platform/3251: Refactor Kubernetes role bindings in main.tf for …

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -94,7 +94,7 @@ resource "kubernetes_cluster_role_v1" "cluster_scoped" {
 
 resource "kubernetes_cluster_role_binding_v1" "cluster_scoped" {
   metadata {
-    name   = var.role_binding_name
+    name   = var.cluster_role_binding_name
     labels = local.k8s_full_labels
   }
 

--- a/main.tf
+++ b/main.tf
@@ -79,33 +79,6 @@ resource "kubernetes_cluster_role_v1" "cluster_scoped" {
     resources  = ["namespaces"]
     verbs      = ["get", "list"]
   }
-}
-
-resource "kubernetes_cluster_role_binding_v1" "cluster_scoped" {
-  metadata {
-    name   = var.role_binding_name
-    labels = local.k8s_full_labels
-  }
-
-  role_ref {
-    api_group = "rbac.authorization.k8s.io"
-    kind      = "ClusterRole"
-    name      = kubernetes_cluster_role_v1.cluster_scoped.metadata[0].name
-  }
-
-  subject {
-    kind      = "ServiceAccount"
-    name      = kubernetes_service_account_v1.this.metadata[0].name
-    namespace = local.cronjob_namespace
-  }
-}
-
-resource "kubernetes_cluster_role_v1" "namespace_scoped" {
-  metadata {
-    name   = "${var.cluster_role_name_prefix}-namespace-scoped"
-    labels = local.k8s_full_labels
-  }
-
   rule {
     api_groups = ["apps"]
     resources  = ["deployments", "statefulsets"]
@@ -119,9 +92,7 @@ resource "kubernetes_cluster_role_v1" "namespace_scoped" {
   }
 }
 
-# This role binding must be created in each namespace where the controller should
-# manage the scale of deployments.
-resource "kubernetes_cluster_role_binding_v1" "this" {
+resource "kubernetes_cluster_role_binding_v1" "cluster_scoped" {
   metadata {
     name   = var.role_binding_name
     labels = local.k8s_full_labels
@@ -130,7 +101,7 @@ resource "kubernetes_cluster_role_binding_v1" "this" {
   role_ref {
     api_group = "rbac.authorization.k8s.io"
     kind      = "ClusterRole"
-    name      = kubernetes_cluster_role_v1.namespace_scoped.metadata[0].name
+    name      = kubernetes_cluster_role_v1.cluster_scoped.metadata[0].name
   }
 
   subject {

--- a/variables.tf
+++ b/variables.tf
@@ -37,8 +37,8 @@ variable "cluster_role_name_prefix" {
   default     = "custom:application-sleep-cycles:controller"
 }
 
-variable "role_binding_name" {
-  description = "Name of the role binding."
+variable "cluster_role_binding_name" {
+  description = "Name of the cluster role binding."
   type        = string
   default     = "custom:application-sleep-cycles:controller"
 }


### PR DESCRIPTION
### **User description**
…clarity and consistency


___

### **PR Type**
Enhancement


___

### **Description**
- Simplified RBAC structure by merging two cluster roles (`cluster_scoped` and `namespace_scoped`) into a single role with combined permissions
- Removed redundant cluster role binding while maintaining all required permissions
- Streamlined permissions for managing namespaces, deployments, and statefulsets under a single role definition
- Improved code maintainability by reducing duplication in role bindings



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Consolidate Kubernetes RBAC roles and bindings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

main.tf

<li>Merged <code>cluster_scoped</code> and <code>namespace_scoped</code> cluster roles into a single <br>role<br> <li> Simplified role bindings by removing redundant binding<br> <li> Combined permissions for namespaces, deployments and statefulsets into <br>one role<br>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-kubernetes-application-sleep-cycles/pull/5/files#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbb">+2/-31</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information